### PR TITLE
Enforce DNS over HTTPS by default

### DIFF
--- a/examples/pihole/docker-compose.yml
+++ b/examples/pihole/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   pihole:
-    image: pihole/pihole:latest
+    image: pihole/pihole:beta-v5.0
     container_name: pihole
     hostname: pihole
     networks:
@@ -32,7 +32,7 @@ services:
       - "PROXY_LOCATION=pihole"
       - "VIRTUAL_PORT=80"
       - "DNS1=172.20.0.3#5053"
-      - "DNS2=1.1.1.1"
+      - "DNS2=no"
     volumes:
       - "./etc-pihole/:/etc/pihole/"
       - "./etc-dnsmasq.d/:/etc/dnsmasq.d/"

--- a/examples/pihole/docker-compose.yml
+++ b/examples/pihole/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   pihole:
-    image: pihole/pihole:beta-v5.0
+    image: pihole/pihole:latest
     container_name: pihole
     hostname: pihole
     networks:


### PR DESCRIPTION
Change the pi-hole DNS2 environment setting to "no" to enforce pi-hole to always use the cloudflared proxy. Otherwise the DNS2 setting (1.1.1.1) will be used and DNS over HTTPS will not be enabled (using https://1.1.1.1/help to check this).