### PR TITLE
fix: use TUNNEL_DNS_PORT in healthcheck command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ENTRYPOINT [ "/usr/local/bin/cloudflared" ]
 CMD [ "proxy-dns" ]
 
 HEALTHCHECK --interval=30s --timeout=20s --start-period=10s \
-  CMD dig +short @127.0.0.1 -p 5053 cloudflare.com A || exit 1
+  CMD dig +short @127.0.0.1 -p $TUNNEL_DNS_PORT cloudflare.com A || exit 1

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Image: crazymax/cloudflared:latest
 
 * `TZ` : The timezone assigned to the container (default `UTC`)
 * `TUNNEL_DNS_UPSTREAM` : Upstream endpoint URL, you can specify multiple endpoints for redundancy. (default `https://1.1.1.1/dns-query,https://1.0.0.1/dns-query`)
-* `TUNNEL_DNS_PORT`: DNS listening port (default `5353`)
+* `TUNNEL_DNS_PORT`: DNS listening port (default `5053`)
 * `TUNNEL_DNS_ADDRESS`: DNS listening IP (default `0.0.0.0` "all interfaces")
 * `TUNNEL_DNS_METRICS`: Prometheus metrics host and port. (default `0.0.0.0:49312`)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Image: crazymax/cloudflared:latest
 
 * `TZ` : The timezone assigned to the container (default `UTC`)
 * `TUNNEL_DNS_UPSTREAM` : Upstream endpoint URL, you can specify multiple endpoints for redundancy. (default `https://1.1.1.1/dns-query,https://1.0.0.1/dns-query`)
+* `TUNNEL_DNS_PORT`: DNS listening port (default `5353`)
+* `TUNNEL_DNS_ADDRESS`: DNS listening IP (default `0.0.0.0` "all interfaces")
+* `TUNNEL_DNS_METRICS`: Prometheus metrics host and port. (default `0.0.0.0:49312`)
 
 ### Ports
 


### PR DESCRIPTION
The port in the healthcheck was hardcoded as 5053, so if a container used another port for the DNS server by setting the TUNNEL_DNS_PORT environment variable, the container always reported as unhealthy.

This change uses the same environment variable in the healthcheck so the health status is reported correctly.