### PR TITLE
fix: replace DNS1 & DNS2 with PIHOLE_DNS_

### DIFF
--- a/examples/pihole/docker-compose.yml
+++ b/examples/pihole/docker-compose.yml
@@ -31,8 +31,7 @@ services:
       - "TZ=Europe/Paris"
       - "PROXY_LOCATION=pihole"
       - "VIRTUAL_PORT=80"
-      - "DNS1=172.20.0.3#5053"
-      - "DNS2=1.1.1.1"
+      - "PIHOLE_DNS_=172.20.0.3#5053;1.1.1.1"
     volumes:
       - "./etc-pihole/:/etc/pihole/"
       - "./etc-dnsmasq.d/:/etc/dnsmasq.d/"


### PR DESCRIPTION
Hi :wave: ,

the environment variables `DNS1` and `DNS2` are deprecated. It is recommended to use `PIHOLE_DNS_` instead. While `DNS1` and `DNS2` may still work, they are likely to be removed in a future version.